### PR TITLE
Docker 18.06 + Monocular 1.0 + transparent proxy + images cache

### DIFF
--- a/cmd/gokube/cmd/init.go
+++ b/cmd/gokube/cmd/init.go
@@ -151,7 +151,11 @@ func initRun(cmd *cobra.Command, args []string) {
 
 	// Deploy Monocular
 	helm.UpgradeWithConfiguration("nginx", "kube-system", "controller.hostNetwork=true", "stable/nginx-ingress", "0.29.2")
-	helm.UpgradeWithConfiguration("gokube", "kube-system", "sync.repos[0].name=miniapps,sync.repos[0].url="+miniappsHelmRepository+",sync.httpProxy="+httpProxy+",sync.httpsProxy="+httpsProxy+",chartsvc.replicas=1,ui.replicaCount=1,ui.image.pullPolicy=IfNotPresent,ui.appName=GoKube,prerender.image.pullPolicy=IfNotPresent", "monocular/monocular", "1.1.0")
+	var goKubeConfiguration = "sync.repos[0].name=miniapps,sync.repos[0].url=" + miniappsHelmRepository + ",chartsvc.replicas=1,ui.replicaCount=1,ui.image.pullPolicy=IfNotPresent,ui.appName=GoKube,prerender.image.pullPolicy=IfNotPresent"
+	if !tproxy && httpProxy != "" && httpsProxy != "" {
+		goKubeConfiguration = goKubeConfiguration + ",sync.httpProxy=" + httpProxy + ",sync.httpsProxy=" + httpsProxy
+	}
+	helm.UpgradeWithConfiguration("gokube", "kube-system", goKubeConfiguration, "monocular/monocular", "1.1.0")
 
 	// Deploy transparent proxy (if requested)
 	if tproxy && httpProxy != "" && httpsProxy != "" {

--- a/cmd/gokube/cmd/init.go
+++ b/cmd/gokube/cmd/init.go
@@ -145,7 +145,7 @@ func initRun(cmd *cobra.Command, args []string) {
 	helm.UpgradeWithConfiguration("gokube", "kube-system", "sync.repos[0].name=miniapps,sync.repos[0].url=https://gemalto.github.io/miniapps,chartsvc.replicas=1,ui.replicaCount=1,ui.image.pullPolicy=IfNotPresent,ui.appName=GoKube,prerender.image.pullPolicy=IfNotPresent", "monocular/monocular", "1.1.0")
 
 	// Deploy transparent proxy (if requested)
-	if tproxy {
+	if tproxy && httpProxy != "" && httpsProxy != "" {
 		helm.UpgradeWithConfiguration("any-proxy", "kube-system", "global.httpProxy="+httpProxy+",global.httpsProxy="+httpsProxy, "miniapps/any-proxy", "1.0.0")
 	}
 

--- a/cmd/gokube/cmd/init.go
+++ b/cmd/gokube/cmd/init.go
@@ -128,6 +128,7 @@ func initRun(cmd *cobra.Command, args []string) {
 		cacheAndTag(alternateCacheImagePath, "chart-repo:v1.0.0", "quay.io/helmpack", dockerEnv)
 		cacheAndTag(alternateCacheImagePath, "chartsvc:v1.0.0", "quay.io/helmpack", dockerEnv)
 		cacheAndTag(alternateCacheImagePath, "monocular-ui:v1.0.0", "quay.io/helmpack", dockerEnv)
+		minikube.Cache("bitnami/mongodb:4.0.3")
 		minikube.Cache("migmartri/prerender:latest")
 
 		if tproxy && httpProxy != "" && httpsProxy != "" {

--- a/cmd/gokube/cmd/init.go
+++ b/cmd/gokube/cmd/init.go
@@ -123,6 +123,10 @@ func initRun(cmd *cobra.Command, args []string) {
 		cacheAndTag(dockerCacheRepository, "chartsvc:v1.0.0", "quay.io/helmpack", dockerEnv)
 		cacheAndTag(dockerCacheRepository, "monocular-ui:v1.0.0", "quay.io/helmpack", dockerEnv)
 		minikube.Cache("migmartri/prerender:latest")
+
+		// Put needed images in cache (any-proxy)
+		minikube.Cache("alpine:3.8")
+		minikube.Cache(dockerCacheRepository + "/any-proxy:1.0.1")
 	}
 
 	// Switch context to minikube for kubectl and helm
@@ -142,7 +146,7 @@ func initRun(cmd *cobra.Command, args []string) {
 
 	// Deploy transparent proxy (if requested)
 	if tproxy {
-		helm.UpgradeWithConfiguration("any-proxy", "kube-system", "global.httpProxy="+httpProxy+",global.httpsProxy="+httpsProxy, "miniapps/any-proxy", "1.0")
+		helm.UpgradeWithConfiguration("any-proxy", "kube-system", "global.httpProxy="+httpProxy+",global.httpsProxy="+httpsProxy, "miniapps/any-proxy", "1.0.0")
 	}
 
 	// Patch kubernetes-dashboard to expose it on nodePort 30000

--- a/cmd/gokube/cmd/init.go
+++ b/cmd/gokube/cmd/init.go
@@ -155,7 +155,7 @@ func initRun(cmd *cobra.Command, args []string) {
 	if !tproxy && httpProxy != "" && httpsProxy != "" {
 		goKubeConfiguration = goKubeConfiguration + ",sync.httpProxy=" + httpProxy + ",sync.httpsProxy=" + httpsProxy
 	}
-	helm.UpgradeWithConfiguration("gokube", "kube-system", goKubeConfiguration, "monocular/monocular", "1.1.0")
+	helm.UpgradeWithConfiguration("gokube", "kube-system", goKubeConfiguration, "monocular/monocular", "1.2.0")
 
 	// Deploy transparent proxy (if requested)
 	if tproxy && httpProxy != "" && httpsProxy != "" {

--- a/cmd/gokube/cmd/init.go
+++ b/cmd/gokube/cmd/init.go
@@ -148,7 +148,7 @@ func initRun(cmd *cobra.Command, args []string) {
 
 	// Deploy Monocular
 	helm.UpgradeWithConfiguration("nginx", "kube-system", "controller.hostNetwork=true", "stable/nginx-ingress", "0.29.2")
-	helm.UpgradeWithConfiguration("gokube", "kube-system", "sync.repos[0].name=miniapps,sync.repos[0].url=https://gemalto.github.io/miniapps,chartsvc.replicas=1,ui.replicaCount=1,ui.image.pullPolicy=IfNotPresent,ui.appName=GoKube,prerender.image.pullPolicy=IfNotPresent", "monocular/monocular", "1.1.0")
+	helm.UpgradeWithConfiguration("gokube", "kube-system", "sync.repos[0].name=miniapps,sync.repos[0].url="+miniappsHelmRepository+",sync.httpProxy="+httpProxy+",sync.httpsProxy="+httpsProxy+",chartsvc.replicas=1,ui.replicaCount=1,ui.image.pullPolicy=IfNotPresent,ui.appName=GoKube,prerender.image.pullPolicy=IfNotPresent", "monocular/monocular", "1.1.0")
 
 	// Deploy transparent proxy (if requested)
 	if tproxy && httpProxy != "" && httpsProxy != "" {

--- a/cmd/gokube/cmd/init.go
+++ b/cmd/gokube/cmd/init.go
@@ -128,7 +128,7 @@ func initRun(cmd *cobra.Command, args []string) {
 		cacheAndTag(alternateCacheImagePath, "chart-repo:v1.0.0", "quay.io/helmpack", dockerEnv)
 		cacheAndTag(alternateCacheImagePath, "chartsvc:v1.0.0", "quay.io/helmpack", dockerEnv)
 		cacheAndTag(alternateCacheImagePath, "monocular-ui:v1.0.0", "quay.io/helmpack", dockerEnv)
-		minikube.Cache("bitnami/mongodb:4.0.3")
+		minikube.Cache("docker.io/bitnami/mongodb:4.0.3")
 		minikube.Cache("migmartri/prerender:latest")
 
 		if tproxy && httpProxy != "" && httpsProxy != "" {

--- a/cmd/gokube/cmd/init.go
+++ b/cmd/gokube/cmd/init.go
@@ -130,7 +130,7 @@ func initRun(cmd *cobra.Command, args []string) {
 		cacheAndTag(alternateCacheImagePath, "monocular-ui:v1.0.0", "quay.io/helmpack", dockerEnv)
 		minikube.Cache("migmartri/prerender:latest")
 
-		if tproxy {
+		if tproxy && httpProxy != "" && httpsProxy != "" {
 			// Put needed images in cache (any-proxy)
 			minikube.Cache("alpine:3.8")
 			minikube.Cache(alternateCacheImagePath + "/any-proxy:1.0.1")

--- a/cmd/gokube/cmd/init.go
+++ b/cmd/gokube/cmd/init.go
@@ -130,9 +130,11 @@ func initRun(cmd *cobra.Command, args []string) {
 		cacheAndTag(alternateCacheImagePath, "monocular-ui:v1.0.0", "quay.io/helmpack", dockerEnv)
 		minikube.Cache("migmartri/prerender:latest")
 
-		// Put needed images in cache (any-proxy)
-		minikube.Cache("alpine:3.8")
-		minikube.Cache(alternateCacheImagePath + "/any-proxy:1.0.1")
+		if tproxy {
+			// Put needed images in cache (any-proxy)
+			minikube.Cache("alpine:3.8")
+			minikube.Cache(alternateCacheImagePath + "/any-proxy:1.0.1")
+		}
 	}
 
 	// Switch context to minikube for kubectl and helm

--- a/cmd/gokube/cmd/version.go
+++ b/cmd/gokube/cmd/version.go
@@ -35,7 +35,7 @@ var versionCmd = &cobra.Command{
 			fmt.Fprintln(os.Stderr, "usage: gokube version")
 			os.Exit(1)
 		}
-		fmt.Println("gokube version: v1.4.0")
+		fmt.Println("gokube version: v1.5.0")
 		minikube.Version()
 		helm.Version()
 		docker.Version()

--- a/pkg/docker/docker.go
+++ b/pkg/docker/docker.go
@@ -26,8 +26,10 @@ import (
 )
 
 const (
-	URL     = "https://download.docker.com/win/static/edge/x86_64/docker-%s-ce.zip"
-	VERSION = "17.10.0"
+	//	URL     = "https://download.docker.com/win/static/edge/x86_64/docker-%s-ce.zip"
+	//	VERSION = "17.10.0"
+	URL     = "https://github.com/StefanScherer/docker-cli-builder/releases/download/%s-ce/docker.exe"
+	VERSION = "18.06.1"
 )
 
 // LoadImages ...
@@ -89,7 +91,7 @@ func Version() {
 func Download(dst string) {
 	if _, err := os.Stat(gokube.GetBinDir() + "/docker.exe"); os.IsNotExist(err) {
 		download.DownloadFromUrl("docker v"+VERSION, URL, VERSION)
-		utils.MoveFile(gokube.GetTempDir()+"/docker/docker.exe", dst+"/docker.exe")
+		utils.MoveFile(gokube.GetTempDir()+"/docker.exe", dst+"/docker.exe")
 		utils.RemoveDir(gokube.GetTempDir())
 	}
 }
@@ -109,5 +111,21 @@ func RemoveImage(image string, envVars []utils.EnvVar) {
 // Purge ...
 func Purge() {
 	utils.RemoveFile(gokube.GetBinDir() + "/docker.exe")
-	utils.RemoveDir(utils.GetUserHome() + "/.docker")
+	utils.CleanDir(utils.GetUserHome() + "/.docker")
+}
+
+// Init ...
+func Init() {
+	var configJsonPath = utils.GetUserHome() + "/.docker/config.json"
+	_, err := os.Stat(configJsonPath)
+	if err == nil {
+		return
+	}
+	newFile, err := os.Create(configJsonPath)
+	if err != nil {
+		fmt.Printf("Error while creating %s\n", configJsonPath)
+	}
+	newFile.WriteString("{}")
+	newFile.Sync()
+	newFile.Close()
 }

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -137,5 +137,5 @@ func Download(dst string, helmVersion string) {
 // Purge ...
 func Purge() {
 	utils.RemoveFile(gokube.GetBinDir() + "/helm.exe")
-	utils.RemoveDir(utils.GetUserHome() + "/.helm")
+	utils.CleanDir(utils.GetUserHome() + "/.helm")
 }

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -99,5 +99,5 @@ func DeleteSecret(name string) {
 // Purge ...
 func Purge() {
 	utils.RemoveFile(gokube.GetBinDir() + "/kubectl.exe")
-	utils.RemoveDir(utils.GetUserHome() + "/.kube")
+	utils.CleanDir(utils.GetUserHome() + "/.kube")
 }

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -33,7 +33,7 @@ const (
 
 // Start ...
 func Start(memory int16, nCPUs int16, diskSize string, httpProxy string, httpsProxy string, npProxy string, insecureRegistry string, kubernetesVersion string) {
-	cmd := exec.Command("minikube", "start", "--kubernetes-version", kubernetesVersion, "--insecure-registry", insecureRegistry, "--docker-env", "HTTP_PROXY="+httpProxy, "--docker-env", "HTTPS_PROXY="+httpsProxy, "--docker-env", "NO_PROXY="+npProxy, "--memory", strconv.FormatInt(int64(memory), 10), "--cpus", strconv.FormatInt(int64(nCPUs), 10), "--disk-size", diskSize, "--network-plugin=cni", "--extra-config=kubelet.network-plugin=cni")
+	cmd := exec.Command("minikube", "start", "--cache-images", "--kubernetes-version", kubernetesVersion, "--insecure-registry", insecureRegistry, "--docker-env", "HTTP_PROXY="+httpProxy, "--docker-env", "HTTPS_PROXY="+httpsProxy, "--docker-env", "NO_PROXY="+npProxy, "--memory", strconv.FormatInt(int64(memory), 10), "--cpus", strconv.FormatInt(int64(nCPUs), 10), "--disk-size", diskSize, "--network-plugin=cni", "--extra-config=kubelet.network-plugin=cni")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Run()

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -28,8 +28,11 @@ import (
 )
 
 // Start ...
-func Start(memory int16, cpus int16, diskSize string, httpProxy string, httpsProxy string, npProxy string, insecureRegistry string, kubernetesVersion string, cache bool) {
-	var args = []string{"start", "--kubernetes-version", kubernetesVersion, "--insecure-registry", insecureRegistry, "--docker-env", "HTTP_PROXY=" + httpProxy, "--docker-env", "HTTPS_PROXY=" + httpsProxy, "--docker-env", "NO_PROXY=" + npProxy, "--memory", strconv.FormatInt(int64(memory), 10), "--cpus", strconv.FormatInt(int64(cpus), 10), "--disk-size", diskSize, "--network-plugin=cni", "--extra-config=kubelet.network-plugin=cni"}
+func Start(memory int16, cpus int16, diskSize string, tproxy bool, httpProxy string, httpsProxy string, noProxy string, insecureRegistry string, kubernetesVersion string, cache bool) {
+	var args = []string{"start", "--kubernetes-version", kubernetesVersion, "--insecure-registry", insecureRegistry, "--memory", strconv.FormatInt(int64(memory), 10), "--cpus", strconv.FormatInt(int64(cpus), 10), "--disk-size", diskSize, "--network-plugin=cni", "--extra-config=kubelet.network-plugin=cni"}
+	if !tproxy {
+		args = append(args, "--docker-env", "HTTP_PROXY="+httpProxy, "--docker-env", "HTTPS_PROXY="+httpsProxy, "--docker-env", "NO_PROXY="+noProxy)
+	}
 	if cache {
 		args = append(args, "--cache-images")
 	}

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -27,13 +27,21 @@ import (
 	"github.com/gemalto/gokube/pkg/utils"
 )
 
-const (
-	URL = "https://storage.googleapis.com/minikube/releases/%s/minikube-windows-amd64.exe"
-)
-
 // Start ...
-func Start(memory int16, nCPUs int16, diskSize string, httpProxy string, httpsProxy string, npProxy string, insecureRegistry string, kubernetesVersion string) {
-	cmd := exec.Command("minikube", "start", "--cache-images", "--kubernetes-version", kubernetesVersion, "--insecure-registry", insecureRegistry, "--docker-env", "HTTP_PROXY="+httpProxy, "--docker-env", "HTTPS_PROXY="+httpsProxy, "--docker-env", "NO_PROXY="+npProxy, "--memory", strconv.FormatInt(int64(memory), 10), "--cpus", strconv.FormatInt(int64(nCPUs), 10), "--disk-size", diskSize, "--network-plugin=cni", "--extra-config=kubelet.network-plugin=cni")
+func Start(memory int16, cpus int16, diskSize string, httpProxy string, httpsProxy string, npProxy string, insecureRegistry string, kubernetesVersion string, cache bool) {
+	var args = []string{"start", "--kubernetes-version", kubernetesVersion, "--insecure-registry", insecureRegistry, "--docker-env", "HTTP_PROXY=" + httpProxy, "--docker-env", "HTTPS_PROXY=" + httpsProxy, "--docker-env", "NO_PROXY=" + npProxy, "--memory", strconv.FormatInt(int64(memory), 10), "--cpus", strconv.FormatInt(int64(cpus), 10), "--disk-size", diskSize, "--network-plugin=cni", "--extra-config=kubelet.network-plugin=cni"}
+	if cache {
+		args = append(args, "--cache-images")
+	}
+	cmd := exec.Command("minikube", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Run()
+}
+
+// Cache ...
+func Cache(image string) {
+	cmd := exec.Command("minikube", "cache", "add", image)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Run()
@@ -74,8 +82,8 @@ func Status() {
 // Delete ...
 func Delete() {
 	cmd := exec.Command("minikube", "delete")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	//	cmd.Stdout = os.Stdout
+	//	cmd.Stderr = os.Stderr
 	cmd.Run()
 }
 
@@ -133,13 +141,9 @@ func DockerEnv() []utils.EnvVar {
 }
 
 // Download ...
-func Download(dst string, minikubeFork string, minikubeVersion string) {
+func Download(dst string, minikubeURI string, minikubeVersion string) {
 	if _, err := os.Stat(dst + "/minikube.exe"); os.IsNotExist(err) {
-		if strings.EqualFold(minikubeFork, "minikube") {
-			download.DownloadFromUrl("minikube "+minikubeVersion, URL, minikubeVersion)
-		} else {
-			download.DownloadFromUrl("minikube forked", minikubeFork, minikubeVersion)
-		}
+		download.DownloadFromUrl("minikube "+minikubeVersion, minikubeURI, minikubeVersion)
 		utils.MoveFile(gokube.GetTempDir()+"/minikube-windows-amd64.exe", dst+"/minikube.exe")
 		utils.RemoveDir(gokube.GetTempDir())
 	}
@@ -148,7 +152,7 @@ func Download(dst string, minikubeFork string, minikubeVersion string) {
 // Purge ...
 func Purge() {
 	utils.RemoveFile(gokube.GetBinDir() + "/minikube.exe")
-	utils.RemoveDir(utils.GetUserHome() + "/.minikube")
+	utils.CleanDir(utils.GetUserHome() + "/.minikube")
 }
 
 func toLinuxPath(path string) string {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/user"
+	"path"
 	"path/filepath"
 )
 
@@ -81,6 +82,20 @@ func CopyFile(src, dst string) error {
 		return err
 	}
 	return out.Close()
+}
+
+// CleanDir ...
+func CleanDir(dirPath string) {
+	dir, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		panic(err)
+	}
+	for _, e := range dir {
+		err := os.RemoveAll(path.Join([]string{dirPath, e.Name()}...))
+		if err != nil {
+			panic(err)
+		}
+	}
 }
 
 // RemoveDir ...


### PR DESCRIPTION
moved to docker 18.06
purge does not remove root directories (better for symlinks)
better management of minikube forks
parametrize miniapps helm repository
support transparent proxy
allow minikube caching
switched to monocular 1.0