### PR TITLE
Bump to minikube 1.3.0, bump to helm spray 3.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.10.x
+  - 1.11.x
 
 go_import_path: github.com/gemalto/gokube
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # GoKube Release Notes
 
+## Version 1.7.0 - 08/06/2019
+* Bump to minikube v1.3.0 (to benefit from the NAT DNS options), bump to helm spray v3.4.3 [#10](https://github.com/gemalto/gokube/pull/10)
+
+## Version 1.6.2 - 05/29/2019
+* kubernetes-dashboard not always patched [#9](https://github.com/gemalto/gokube/pull/9)
+
+## Version 1.6.1 - 05/22/2019
+* Fix for kubernetes-dashboard not always patched [#8](https://github.com/gemalto/gokube/issues/8)
+
 ## Version 1.6.0 - 04/02/2019
 * Bump to minikube v1.0.0 [#7](https://github.com/gemalto/gokube/pull/7)
 

--- a/cmd/gokube/cmd/init.go
+++ b/cmd/gokube/cmd/init.go
@@ -37,7 +37,7 @@ const (
 	NGINX_INGRESS_APP_VERSION  = "0.23.0"
 	TPROXY_CHART_VERSION       = "1.0.0"
 	DEFAULT_KUBERNETES_VERSION = "v1.10.13"
-	DEFAULT_MINIKUBE_VERSION   = "v1.2.0"
+	DEFAULT_MINIKUBE_VERSION   = "v1.3.0"
 )
 
 var minikubeURL string
@@ -89,7 +89,7 @@ func init() {
 	initCmd.Flags().StringVarP(&kubernetesVersion, "kubernetes-version", "", defaultKubernetesVersion, "The kubernetes version")
 	initCmd.Flags().StringVarP(&kubectlVersion, "kubectl-version", "", "v1.13.6", "The kubectl version")
 	initCmd.Flags().StringVarP(&helmVersion, "helm-version", "", "v2.13.1", "The helm version")
-	initCmd.Flags().StringVarP(&helmSprayVersion, "helm-spray-version", "", "v3.4.2", "The helm version")
+	initCmd.Flags().StringVarP(&helmSprayVersion, "helm-spray-version", "", "v3.4.3", "The helm version")
 	initCmd.Flags().StringVarP(&sternVersion, "stern-version", "", "1.10.0", "The stern version")
 	initCmd.Flags().Int16VarP(&memory, "memory", "", int16(8192), "Amount of RAM allocated to the minikube VM in MB")
 	initCmd.Flags().Int16VarP(&cpus, "cpus", "", int16(4), "Number of CPUs allocated to the minikube VM")
@@ -177,7 +177,10 @@ func initRun(cmd *cobra.Command, args []string) {
 	// Checks minikube IP
 	var minikubeIP = minikube.Ip()
 	if strings.Compare("0.0.0.0", checkIP) != 0 && strings.Compare(checkIP, minikubeIP) != 0 {
-		log.Fatalf("Minikube IP (%s) does not match expected IP (%s)", minikubeIP, checkIP)
+		log.Println("!!!!!!!!!!!!!!!!!!!!!!!!!")
+		log.Println("!!!!!!!! CAUTION !!!!!!!!")
+		log.Println("!!!!!!!!!!!!!!!!!!!!!!!!!")
+		log.Fatalf("Minikube IP (%s) does not match expected IP (%s), VM post-installation process aborted", minikubeIP, checkIP)
 	}
 
 	if imageCache {

--- a/cmd/gokube/cmd/version.go
+++ b/cmd/gokube/cmd/version.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	GOKUBE_VERSION = "1.6.2"
+	GOKUBE_VERSION = "1.7.0"
 )
 
 // versionCmd represents the version command

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -28,13 +28,19 @@ import (
 )
 
 // Start ...
-func Start(memory int16, cpus int16, diskSize string, tproxy bool, httpProxy string, httpsProxy string, noProxy string, insecureRegistry string, kubernetesVersion string, cache bool) {
+func Start(memory int16, cpus int16, diskSize string, tproxy bool, httpProxy string, httpsProxy string, noProxy string, insecureRegistry string, kubernetesVersion string, cache bool, dnsProxy bool, hostDNSResolver bool) {
 	var args = []string{"start", "--kubernetes-version", kubernetesVersion, "--insecure-registry", insecureRegistry, "--memory", strconv.FormatInt(int64(memory), 10), "--cpus", strconv.FormatInt(int64(cpus), 10), "--disk-size", diskSize, "--network-plugin=cni", "--enable-default-cni"}
 	if !tproxy {
 		args = append(args, "--docker-env", "HTTP_PROXY="+httpProxy, "--docker-env", "HTTPS_PROXY="+httpsProxy, "--docker-env", "NO_PROXY="+noProxy)
 	}
 	if !cache {
 		args = append(args, "--cache-images=false")
+	}
+	if dnsProxy {
+		args = append(args, "--dns-proxy")
+	}
+	if !hostDNSResolver {
+		args = append(args, "--host-dns-resolver=false")
 	}
 	cmd := exec.Command("minikube", args...)
 	cmd.Stdout = os.Stdout

--- a/pkg/virtualbox/virtualbox.go
+++ b/pkg/virtualbox/virtualbox.go
@@ -54,6 +54,14 @@ type dhcpServer struct {
 var ErrNetworkAddrCidr = errors.New("host-only cidr must be specified with a host address, not a network address")
 var vboxManager = NewVBoxManager()
 
+// DeactivateNatDnsHostResolver...
+func DeactivateNatDnsHostResolver() {
+	err := vboxManager.vbm("modifyvm", "minikube", "--natdnshostresolver1", "off")
+	if err != nil {
+		panic(err)
+	}
+}
+
 // PurgeHostOnlyNetwork ...
 func PurgeHostOnlyNetwork() {
 	nets, err := listHostOnlyAdapters(vboxManager)


### PR DESCRIPTION
Bump to minikube 1.3.0 (to benefit from the new DNS NAT flags of minikube)
Bump to helm spray 3.4.3
Display a bigger error message when VM IP is not the expected one
